### PR TITLE
[bugfix] argument overwrite in bintrace.py/trace_mem_access function

### DIFF
--- a/harness/fuzzware_harness/tracing/bintrace.py
+++ b/harness/fuzzware_harness/tracing/bintrace.py
@@ -18,10 +18,11 @@ trace_file = None
 
 def trace_mem_access(uc, target, access, address, size, value):
     global trace_file
+    access_type = access
     event = TraceEvent.new_message()
     access = event.init('access')
     access.target = target
-    access.type = "write" if access == UC_MEM_WRITE else "read"
+    access.type = "write" if access_type == UC_MEM_WRITE else "read"
     access.size = size
     access.pc = uc.reg_read(UC_ARM_REG_PC)
     access.address = address


### PR DESCRIPTION
Since the trace_mem_access function in bintrace.py use the name `access` as parameter, the `access = event.init('access')` will overwrite this argument, causing `access.type` always be `read`.