### PR TITLE
Log pc and lr while emulating + guess lr symbol

### DIFF
--- a/harness/fuzzware_harness/harness.py
+++ b/harness/fuzzware_harness/harness.py
@@ -15,7 +15,7 @@ from .tracing import snapshot, trace_bbs, trace_ids, trace_mem
 from .user_hooks import (add_block_hook, add_func_hook,
                          maybe_register_global_block_hook)
 from .util import (bytes2int, load_config_deep, parse_address_value,
-                   parse_symbols, resolve_region_file_paths, guess_symbol)
+                   parse_symbols, resolve_region_file_paths, closest_symbol)
 
 logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
 logger = logging.getLogger("emulator")
@@ -24,7 +24,7 @@ def unicorn_trace_syms(uc, pc, size=0, user_data=None):
     if pc in uc.syms_by_addr:
         print(f"Calling function: {uc.syms_by_addr[pc]}", flush=False, end="")
         lr = uc.regs.lr
-        lr_sym = guess_symbol(uc.syms_by_addr, lr)
+        lr_sym = closest_symbol(uc.syms_by_addr, lr)[0]
         if lr_sym:
             print(f" from {lr_sym}", flush=False, end="")
         print(f" (PC={hex(pc)}, LR={hex(lr)})", flush=True)

--- a/harness/fuzzware_harness/harness.py
+++ b/harness/fuzzware_harness/harness.py
@@ -15,14 +15,19 @@ from .tracing import snapshot, trace_bbs, trace_ids, trace_mem
 from .user_hooks import (add_block_hook, add_func_hook,
                          maybe_register_global_block_hook)
 from .util import (bytes2int, load_config_deep, parse_address_value,
-                   parse_symbols, resolve_region_file_paths)
+                   parse_symbols, resolve_region_file_paths, guess_symbol)
 
 logging.basicConfig(stream=sys.stdout, level=logging.WARNING)
 logger = logging.getLogger("emulator")
 
-def unicorn_trace_syms(uc, address, size=0, user_data=None):
-    if address in uc.syms_by_addr:
-        print(f"Calling function: {uc.syms_by_addr[address]}", flush=True)
+def unicorn_trace_syms(uc, pc, size=0, user_data=None):
+    if pc in uc.syms_by_addr:
+        print(f"Calling function: {uc.syms_by_addr[pc]}", flush=False, end="")
+        lr = uc.regs.lr
+        lr_sym = guess_symbol(uc.syms_by_addr, lr)
+        if lr_sym:
+            print(f" from {lr_sym}", flush=False, end="")
+        print(f" (PC={hex(pc)}, LR={hex(lr)})", flush=True)
         sys.stdout.flush()
 
 def configure_unicorn(args):

--- a/harness/fuzzware_harness/util.py
+++ b/harness/fuzzware_harness/util.py
@@ -186,16 +186,3 @@ def load_config_deep(path):
     if config is None:
         return {}
     return resolve_config_includes(config, path)
-
-def guess_symbol(syms_by_addr, address):
-    """
-    Guess the (function) symbol of a memory address, that is, return the
-    one that's nearest when decreasing the address.
-    """
-
-    current = None
-    for addr in syms_by_addr:
-        if addr > address:
-            break
-        current = syms_by_addr[addr]
-    return current

--- a/harness/fuzzware_harness/util.py
+++ b/harness/fuzzware_harness/util.py
@@ -186,3 +186,16 @@ def load_config_deep(path):
     if config is None:
         return {}
     return resolve_config_includes(config, path)
+
+def guess_symbol(syms_by_addr, address):
+    """
+    Guess the (function) symbol of a memory address, that is, return the
+    one that's nearest when decreasing the address.
+    """
+
+    current = None
+    for addr in syms_by_addr:
+        if addr > address:
+            break
+        current = syms_by_addr[addr]
+    return current


### PR DESCRIPTION
This adds more info to the output of `-t`, that is, logging the pc (the address of the function) and the lr. This makes debugging easier.

Also, a function is added that tries to guess the symbol of lr. We need to guess, since symbols only point to the beginning of the function. Guessing is thereby done, by just taking the first symbol that has a lower address than lr.