### PR TITLE
Handle segfault when trying to remove from empty list

### DIFF
--- a/harness/fuzzware_harness/native/timer.c
+++ b/harness/fuzzware_harness/native/timer.c
@@ -195,7 +195,12 @@ static inline void remove_active_timer(struct Timer *tim) {
     if(cursor == tim ) {
         // We are changing the front, so also the intermediate ticks
         timers.active_head = tim->next;
-        timers.cur_countdown = timers.cur_interval = timers.active_head->ticker_val;
+        if (timers.active_head == NULL) {
+            timers.cur_countdown = MAX_RELOAD_VAL;
+            timers.cur_interval = MAX_RELOAD_VAL;
+        } else {
+            timers.cur_countdown = timers.cur_interval = timers.active_head->ticker_val;
+        }
     } else {
         // We are changing something in the middle, we can just unlink it
         for(; cursor->next != tim; cursor = cursor->next);


### PR DESCRIPTION
When running the pipeline/emulator with `fuzz_consumption_timeout` set to 0 (no limit), the emulator would segfault as it would try to remove timers from an already empty list and try to dereference a null pointer when accessing `timers.active_head->ticker_val`. This PR just adds a NULL check to avoid that. 

Bug found and fixed with the help of @nhukc.